### PR TITLE
Small fixes to make it work

### DIFF
--- a/lambda-functions/make-change-tutorial/make_change.py
+++ b/lambda-functions/make-change-tutorial/make_change.py
@@ -15,10 +15,10 @@ def lambda_handler(event, context):
     
     # check that the request has some input body
     if 'body' in event:
-        body = json.loads(event["body"])
+        event = json.loads(event["body"])
 
     # get float "amount"
-    amount = float(body["amount"])
+    amount = float(event["amount"])
 
     # calculate the resultant change and store the result (res)
     res = []


### PR DESCRIPTION
The way it was before it is returning error:
```
{
  "errorMessage": "local variable 'body' referenced before assignment",
  "errorType": "UnboundLocalError",
  "stackTrace": [
    [
      "/var/task/lambda_function.py",
      21,
      "lambda_handler",
      "amount = float(body[\"amount\"])"
    ]
  ]
}
```

Sorry if I made the PR so simple.