### PR TITLE
fix: add pylint package version

### DIFF
--- a/project-ml-microservice-kubernetes/requirements.txt
+++ b/project-ml-microservice-kubernetes/requirements.txt
@@ -11,3 +11,4 @@ scikit-learn==0.20.3
 scipy==1.3.1
 six==1.12.0
 Werkzeug==0.16.0
+pylint==2.4.4


### PR DESCRIPTION
Add pylint package in requirements.txt, this prevent error "pylint command not found" when execute "make lint".