### PR TITLE
fix: disable pylint W1202 message

### DIFF
--- a/project-ml-microservice-kubernetes/Makefile
+++ b/project-ml-microservice-kubernetes/Makefile
@@ -26,6 +26,6 @@ lint:
 	hadolint Dockerfile
 	# This is a linter for Python source code linter: https://www.pylint.org/
 	# This should be run from inside a virtualenv
-	pylint --disable=R,C,W1203 app.py
+	pylint --disable=R,C,W1203,W1202 app.py
 
 all: install lint test


### PR DESCRIPTION
Disable W1202 message when execute "make lint".

![pylint1](https://user-images.githubusercontent.com/20761454/74617888-33e10b80-510e-11ea-8b85-9c677ccc6aae.png)

Now finish correctly.

![pylint2](https://user-images.githubusercontent.com/20761454/74617951-7c002e00-510e-11ea-84b9-336a901ea6f2.png)



