### PR TITLE
Include virtual environment link to Python Documentation

### DIFF
--- a/project-ml-microservice-kubernetes/README.md
+++ b/project-ml-microservice-kubernetes/README.md
@@ -25,16 +25,19 @@ You can find a detailed [project rubric, here](https://review.udacity.com/#!/rub
 
 ## Setup the Environment
 
-* Create a virtualenv with Python 3.7 and activate it. Refer to this link for help on specifying the Python version in the virtualenv. 
+`Virtual Environment` - It's recommended to leverage a virtual environment whenever using Python for projects. This keeps your dependencies for each project separate and organized. Instructions for setting up a virtual environment for your platform can be found in the [python docs](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
+
+* Create a siloed virtual environment with Python 3.7 and **activate** it. You should have Python 3.7 available in your host/local machine. 
+Check the Python path using `which python3`
 ```bash
-python3 -m pip install --user virtualenv
-# You should have Python 3.7 available in your host. 
-# Check the Python path using `which python3`
-# Use a command similar to this one:
-python3 -m virtualenv --python=<path-to-Python3.7> .devops
+python3 -m pip install --user virtualenv 
+# use a command similar to this one to create environment:
+python3 -m virtualenv --python=<path-to-python3.7> .devops
 source .devops/bin/activate
 ```
-* Run `make install` to install the necessary dependencies
+> Alternatively, you could setup the virtualenv via `make setup`. [this](./Makefile) is from a directive in `Makefile`.
+
+- Run `make install` to install the necessary dependencies. This will install all relevant pip packages for the project.
 
 ### Running `app.py`
 

--- a/project-ml-microservice-kubernetes/README.md
+++ b/project-ml-microservice-kubernetes/README.md
@@ -25,7 +25,7 @@ You can find a detailed [project rubric, here](https://review.udacity.com/#!/rub
 
 ## Setup the Environment
 
-`Virtual Environment` - It's recommended to leverage a virtual environment whenever using Python for projects. This keeps your dependencies for each project separate and organized. Instructions for setting up a virtual environment for your platform can be found in the [python docs](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
+`Virtual Environment` - It's recommended to leverage a virtual environment whenever using Python for projects. This keeps your dependencies for each project separate and organized. Instructions for setting up a virtual environment for your platform can be found in the [Python docs](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
 
 * Create a siloed virtual environment with Python 3.7 and **activate** it. You should have Python 3.7 available in your host/local machine. 
 Check the Python path using `which python3`


### PR DESCRIPTION
Setup the Environment 
'Create a virtualenv with Python 3.7 and activate it. Refer to this link for help on specifying the Python version in the virtualenv.'
- This line in the README.md file of the 'project' references a link that's not included.  We could improve the README file to point the learner to resources to read more about Python virtual environments.